### PR TITLE
[fix]breadcrumb

### DIFF
--- a/src/ejs/blog-detail.ejs
+++ b/src/ejs/blog-detail.ejs
@@ -4,7 +4,7 @@
   <body>
     <%- include('./common/_p-header') %>
     <div class="l-breadcrumb l-breadcrumb--blog-detail">
-      <%- include('./component/_c-breadcrumb',{page_title:'ブログ記事一覧'}) %>
+      <%- include('./component/_c-breadcrumb',{page_title:'ブログ記事一覧', posttitle:'お知らせ'}) %>
     </div>
     <div class="l-blog-detail js-mv">
       <%- include('./project/_p-blog-detail') %>

--- a/src/ejs/blog.ejs
+++ b/src/ejs/blog.ejs
@@ -7,7 +7,7 @@
       <%- include('./project/_p-lower-mv',{text:'ブログ'}) %>
     </section>
     <div class="l-breadcrumb">
-      <%- include('./component/_c-breadcrumb',{page_title:'ブログ'}) %>
+      <%- include('./component/_c-breadcrumb',{page_title:'ブログ', posttitle:''}) %>
     </div>
     <div class="l-blog">
       <%- include('./project/_p-blog') %>

--- a/src/ejs/component/_c-breadcrumb.ejs
+++ b/src/ejs/component/_c-breadcrumb.ejs
@@ -8,5 +8,13 @@
       <p>&nbsp;&gt;&nbsp;</p>
       <a href="#"><%= page_title %></a>
     </li>
+
+    <% if( ! posttitle == "" ) { %>
+      <li class="c-breadcrumb__item">
+        <p>&nbsp;&gt;&nbsp;</p>
+        <a href="#" class="c-breadcrumb__link"><%= posttitle %></a>
+      </li>
+      <% } %>
+  
   </ul>
 </div>

--- a/src/ejs/content.ejs
+++ b/src/ejs/content.ejs
@@ -7,7 +7,7 @@
       <%- include('./project/_p-lower-mv',{text:'事業概要'}) %>
     </section>
     <div class="l-breadcrumb">
-      <%- include('./component/_c-breadcrumb',{page_title:'事業概要'}) %>
+      <%- include('./component/_c-breadcrumb',{page_title:'事業概要', posttitle:''}) %>
     </div>
     <div class="l-content">
       <%- include('./project/_p-content') %>

--- a/src/ejs/news.ejs
+++ b/src/ejs/news.ejs
@@ -8,7 +8,7 @@
     </section>
 
     <div class="l-breadcrumb">
-      <%- include('./component/_c-breadcrumb',{page_title:'お知らせ'}) %>
+      <%- include('./component/_c-breadcrumb',{page_title:'お知らせ', posttitle:''}) %>
     </div>
 
     <main class="p-news">

--- a/src/ejs/overview.ejs
+++ b/src/ejs/overview.ejs
@@ -8,7 +8,7 @@
     </section>
 
     <div class="l-breadcrumb">
-      <%- include('./component/_c-breadcrumb',{page_title:'企業概要'}) %>
+      <%- include('./component/_c-breadcrumb',{page_title:'企業概要', posttitle:''}) %>
     </div>
 
     <div class="l-overview">

--- a/src/ejs/works.ejs
+++ b/src/ejs/works.ejs
@@ -8,7 +8,7 @@
     </section>
 
     <div class="l-breadcrumb">
-      <%- include('./component/_c-breadcrumb',{page_title:'制作実績'}) %>
+      <%- include('./component/_c-breadcrumb',{page_title:'制作実績', posttitle:''}) %>
     </div>
 
     <div class="l-works">


### PR DESCRIPTION
パンクズを動的にしました。

使い方ですが、

`  <%- include('./component/_c-breadcrumb',{page_title:'ブログ記事一覧', posttitle:'お知らせ'}) %>`

のようにposttitleに投稿記事のタイトルを入れてください。